### PR TITLE
Allow limit exceeded errors to be retried

### DIFF
--- a/Sources/Cirrus/Error+CloudKit.swift
+++ b/Sources/Cirrus/Error+CloudKit.swift
@@ -80,8 +80,13 @@ extension Error {
     with block: @escaping () -> Void
   ) -> Bool {
     guard let effectiveError = self as? CKError else { return false }
-
-    guard let retryDelay: Double = effectiveError.retryAfterSeconds else {
+    
+    let retryDelay: Double
+    if let suggestedRetryDelay = effectiveError.retryAfterSeconds {
+      retryDelay = suggestedRetryDelay
+    } else if effectiveError.code == CKError.Code.limitExceeded {
+      retryDelay = 0
+    } else {
       logger?("Error is not recoverable", .error)
       return false
     }


### PR DESCRIPTION
The current implementation of retryCloudKitOperationIfPossible() only performs a retry if a value for retryAfterSeconds is present. However, 'limit exceeded' errors by CloudKit do not include a value for retryAfterSeconds ([see Apple documentation](https://developer.apple.com/documentation/cloudkit/ckerror/2299866-retryafterseconds)). This caused retries of limit exceeded errors not to be performed. Because the entries remain 'cached' in the upload/delete buffer, this also effectively prevents any further uploads/deletions as Cirrus tries to bundle any other updates with the ones still in the buffer.

This fixes that by using a default delay of 0 for limit exceeded errors.

An alternative solution would be to not use retryCloudKitOperationIfPossible() at all, and simply directly perform the chunked requests. It might be a bit cleaner, at the loss of some logging (and there's a possibility that Apple in the future will include a value for retryAfterSeconds'for these errors).