### PR TITLE
Fix skipping encoding keys with nil value

### DIFF
--- a/Sources/CKRecordCoder/CKRecordEncoder.swift
+++ b/Sources/CKRecordCoder/CKRecordEncoder.swift
@@ -39,7 +39,7 @@ public final class CKRecordEncoder {
     return record
   }
 
-  private func validateSize(for recordKeyValues: [String: CKRecordValue]) throws {
+  private func validateSize(for recordKeyValues: [String: CKRecordValue?]) throws {
     guard
       let recordData = try? NSKeyedArchiver.archivedData(
         withRootObject: recordKeyValues,
@@ -90,7 +90,7 @@ final class _CKRecordEncoder {
 extension _CKRecordEncoder {
   final class Storage {
     private(set) var record: CKRecord?
-    private(set) var keys: [String: CKRecordValue] = [:]
+    private(set) var keys: [String: CKRecordValue?] = [:]
 
     func set(record: CKRecord?) {
       self.record = record

--- a/Sources/CKRecordCoder/CKRecordKeyedEncodingContainer.swift
+++ b/Sources/CKRecordCoder/CKRecordKeyedEncodingContainer.swift
@@ -16,6 +16,22 @@ final class CKRecordKeyedEncodingContainer<Key: CodingKey> {
 }
 
 extension CKRecordKeyedEncodingContainer: KeyedEncodingContainerProtocol {
+  func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+    if let value {
+      try encode(value, forKey: key)
+    } else {
+      try encodeNil(forKey: key)
+    }
+  }
+  
+  func encodeIfPresent(_ value: String?, forKey key: Key) throws {
+    if let value {
+      try encode(value, forKey: key)
+    } else {
+      try encodeNil(forKey: key)
+    }
+  }
+  
   func encodeNil(forKey key: Key) throws {
     storage.encode(codingPath: codingPath + [key], value: nil)
   }


### PR DESCRIPTION
CKRecordKeyedEncodingContainer skips encoding any keys that have nil values. This results in CKRecords modification issue where if the record already has non-nil value for the key, it remains unchanged and is not set to nil even if the model has nil value for the key.